### PR TITLE
譲渡アイテムの複数ワード検索機能追加

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,11 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+
+//= require jquery3
+//= require popper
+//= require bootstrap-sprockets
+
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks

--- a/app/assets/javascripts/bartered_items.coffee
+++ b/app/assets/javascripts/bartered_items.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,8 @@
  *= require_tree .
  *= require_self
  */
+ 
+ @import "bootstrap";
+ @import 'font-awesome-sprockets';
+ @import 'font-awesome';
+ 

--- a/app/assets/stylesheets/bartered_items.scss
+++ b/app/assets/stylesheets/bartered_items.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the bartered_items controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/bartered_items_controller.rb
+++ b/app/controllers/bartered_items_controller.rb
@@ -1,4 +1,5 @@
 class BarteredItemsController < ApplicationController
+  
   def new
     @bartered_item = BarteredItem.new
   end
@@ -14,17 +15,37 @@ class BarteredItemsController < ApplicationController
   
   def show
     @bartered_item = BarteredItem.find(params[:id])
+    if @bartered_item.is_deleted == true
+      redirect_to root_path
+    end
   end
 
   def edit
+    @bartered_item = BarteredItem.find(params[:id])
+    if @bartered_item.is_deleted == true
+      redirect_to root_path
+    end
   end
-
+  
+  def update
+    @bartered_item = BarteredItem.find(params[:id])
+    @bartered_item.update(bartered_item_params)
+    redirect_to bartered_item_path(@bartered_item.id)
+  end
+  
+  def delete
+    @bartered_item = BarteredItem.find(params[:id])
+    @bartered_item.update(is_deleted: true)
+    redirect_to root_path
+  end
+  
+  
   def index
   end
   
 private
   def bartered_item_params
-    params.require(:bartered_item).permit(:user_id, :title, :explanation, :barter_way, :desired_place, :no1_wanted_item_id, :no2_wanted_item_id, :no3_wanted_item_id, bartered_item_images_images: [])
+    params.require(:bartered_item).permit(:user_id, :title, :explanation, :barter_way, :desired_place, :no1_wanted_item_id, :no2_wanted_item_id, :no3_wanted_item_id, :barter_status, bartered_item_images_images: [])
   end
 
 end

--- a/app/controllers/bartered_items_controller.rb
+++ b/app/controllers/bartered_items_controller.rb
@@ -39,8 +39,25 @@ class BarteredItemsController < ApplicationController
     redirect_to root_path
   end
   
-  
   def index
+    @bartered_items = BarteredItem.where(is_deleted: false)
+  end
+  
+  def search
+    keywords = params[:keyword].split(/[[:blank:]]+/).select(&:present?)
+    if keywords.present?
+      bartered_items_false = BarteredItem.where(is_deleted: false)
+      keywords.inject(bartered_items_false) do |bartered_items,keyword|
+        @items = bartered_items.where("title like?", "%#{keyword}%").or(bartered_items.where("explanation like?", "%#{keyword}%"))
+      end
+      @bartered_items = @items.distinct
+      @keyword = params[:keyword]
+      render "index"
+    else
+      flash[:notice] = '検索欄が未入力です。検索する際は、文字を入力して下さい。'
+      @bartered_items = BarteredItem.all
+      redirect_to bartered_items_path
+    end
   end
   
 private

--- a/app/controllers/bartered_items_controller.rb
+++ b/app/controllers/bartered_items_controller.rb
@@ -1,0 +1,15 @@
+class BarteredItemsController < ApplicationController
+  def new
+  end
+  
+  def show
+  end
+
+  def edit
+  end
+
+  def index
+  end
+
+
+end

--- a/app/controllers/bartered_items_controller.rb
+++ b/app/controllers/bartered_items_controller.rb
@@ -1,8 +1,19 @@
 class BarteredItemsController < ApplicationController
   def new
+    @bartered_item = BarteredItem.new
+  end
+  
+  def create
+    @bartered_item = BarteredItem.new(bartered_item_params)
+    if @bartered_item.save!
+      redirect_to bartered_item_path(@bartered_item.id)
+    else
+      render :new
+    end
   end
   
   def show
+    @bartered_item = BarteredItem.find(params[:id])
   end
 
   def edit
@@ -10,6 +21,10 @@ class BarteredItemsController < ApplicationController
 
   def index
   end
-
+  
+private
+  def bartered_item_params
+    params.require(:bartered_item).permit(:user_id, :title, :explanation, :barter_way, :desired_place, :no1_wanted_item_id, :no2_wanted_item_id, :no3_wanted_item_id, bartered_item_images_images: [])
+  end
 
 end

--- a/app/helpers/bartered_items_helper.rb
+++ b/app/helpers/bartered_items_helper.rb
@@ -1,0 +1,2 @@
+module BarteredItemsHelper
+end

--- a/app/models/bartered_item.rb
+++ b/app/models/bartered_item.rb
@@ -1,0 +1,2 @@
+class BarteredItem < ApplicationRecord
+end

--- a/app/models/bartered_item.rb
+++ b/app/models/bartered_item.rb
@@ -1,2 +1,21 @@
 class BarteredItem < ApplicationRecord
+  has_many :bartered_item_images, dependent: :destroy
+  belongs_to :user
+  accepts_attachments_for :bartered_item_images, attachment: :image
+  
+  enum barter_way:{郵送のみ:0,手渡しのみ:1,郵送・手渡し両方可:2}
+  enum desired_place:{
+     郵送:0,
+     北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,
+     茨城県:8,栃木県:9,群馬県:10,埼玉県:11,千葉県:12,東京都:13,神奈川県:14,
+     新潟県:15,富山県:16,石川県:17,福井県:18,山梨県:19,長野県:20,
+     岐阜県:21,静岡県:22,愛知県:23,三重県:24,
+     滋賀県:25,京都府:26,大阪府:27,兵庫県:28,奈良県:29,和歌山県:30,
+     鳥取県:31,島根県:32,岡山県:33,広島県:34,山口県:35,
+     徳島県:36,香川県:37,愛媛県:38,高知県:39,
+     福岡県:40,佐賀県:41,長崎県:42,熊本県:43,大分県:44,宮崎県:45,鹿児島県:46, 
+     沖縄県:47
+     }
+  enum barter_status:{募集中:0, 取引終了:1}
+  
 end

--- a/app/models/bartered_item_image.rb
+++ b/app/models/bartered_item_image.rb
@@ -1,0 +1,4 @@
+class BarteredItemImage < ApplicationRecord
+  belongs_to :bartered_item
+  attachment :image
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_many :bartered_items, dependent: :destroy
 end

--- a/app/views/bartered_items/edit.html.erb
+++ b/app/views/bartered_items/edit.html.erb
@@ -1,2 +1,74 @@
-<h1>BarteredItems#edit</h1>
-<p>Find me in app/views/bartered_items/edit.html.erb</p>
+<div class='container'>
+  
+  <div class="row" style="margin:30px 50px 40px 20px">
+    <div class="col-lg-4 offset-lg-2">
+      <h3 style="background-color: #FFE28C;vertical-align: middle;text-align: center;">譲渡アイテム　編集</h3>
+    </div>
+  </div>
+  
+  <%= form_with model:@bartered_item, local:true do |f| %>
+  <div class='row'>
+    <div class="col-lg-2">画像アップロード</div>
+    <div class="col-lg-2">
+      <div class="form-group">
+        <%= f.attachment_field :bartered_item_images_images, multiple: true %>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-lg-2">タイトル</div>
+    <div class="col-lg-4">
+      <div class="form-group">
+        <%= f.text_field :title, class:"form-control"%>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-lg-2">譲渡アイテム詳細</div>
+    <div class="col-lg-4">
+      <div class="form-group">
+        <%= f.text_field :explanation, class:"form-control"%>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-lg-2">交換方法</div>
+    <div class="col-lg-4">
+      <div class="form-group">
+        <%= f.radio_button :barter_way, :郵送のみ %>
+        <%= f.label :barter_way, '郵送のみ' %>
+        <%= f.radio_button :barter_way, :手渡しのみ %>
+        <%= f.label :barter_way, '手渡しのみ' %>
+        <%= f.radio_button :barter_way, :郵送・手渡し両方可%>
+        <%= f.label :barter_way, '郵送・手渡し両方可' %>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-lg-2">交換希望場所</div>
+    <div class="col-lg-4">
+      <div>
+        <%= f.select :desired_place, BarteredItem.desired_places.keys, {} %>
+      </div>
+    </div>
+  </div>
+  <br>
+  <div class="row">
+    <div class="col-lg-2">取引状態</div>
+    <div class="col-lg-4">
+      <div>
+        <%= f.select :barter_status, BarteredItem.barter_statuses.keys, {} %>
+      </div>
+    </div>
+  </div>
+  <div class="row" style="margin:30px 10px 0px 10px">
+    <div class="col-lg-2 offset-lg-2">    
+      <%= f.hidden_field :user_id, :value => current_user.id %>
+      <%= f.submit "更新",class:"btn btn-warning" %>
+      <% end %>
+    </div>
+    <div class="col-lg-2">
+        <%= link_to "削除する", barter_delete_path,method: :patch,"data-confirm" => "削除しますか", class: "btn btn-danger" %>
+    </div>
+  </div>
+</div>

--- a/app/views/bartered_items/edit.html.erb
+++ b/app/views/bartered_items/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>BarteredItems#edit</h1>
+<p>Find me in app/views/bartered_items/edit.html.erb</p>

--- a/app/views/bartered_items/index.html.erb
+++ b/app/views/bartered_items/index.html.erb
@@ -1,2 +1,18 @@
-<h1>BarteredItems#index</h1>
-<p>Find me in app/views/bartered_items/index.html.erb</p>
+<h3>譲渡アイテム　一覧</h3>
+
+<% @bartered_items.each do |bartered_item| %>
+  <%= link_to bartered_item_path(bartered_item.id) do %>
+    <%= bartered_item.user.nick_name %>
+    <br>
+    <%= bartered_item.title %>
+    <br>
+      <% if bartered_item.bartered_item_images.present? %>
+        <% bartered_item.bartered_item_images.each do |image| %>
+          <%= attachment_image_tag image, :image, class: "default_image" %>
+          <br>
+        <% end %>
+      <% else %>
+        画像はありません。
+      <% end %>
+  <% end %>
+<% end %>

--- a/app/views/bartered_items/index.html.erb
+++ b/app/views/bartered_items/index.html.erb
@@ -1,0 +1,2 @@
+<h1>BarteredItems#index</h1>
+<p>Find me in app/views/bartered_items/index.html.erb</p>

--- a/app/views/bartered_items/new.html.erb
+++ b/app/views/bartered_items/new.html.erb
@@ -1,7 +1,7 @@
 <div class='container'>
   
   <div class="row" style="margin:30px 50px 40px 20px">
-    <div class="col-lg-3 offset-lg-2">
+    <div class="col-lg-4 offset-lg-2">
       <h3 style="background-color: #FFE28C;vertical-align: middle;text-align: center;">譲渡アイテム 新規追加</h3>
     </div>
   </div>

--- a/app/views/bartered_items/new.html.erb
+++ b/app/views/bartered_items/new.html.erb
@@ -1,0 +1,2 @@
+<h1>BarteredItems#new</h1>
+<p>Find me in app/views/bartered_items/new.html.erb</p>

--- a/app/views/bartered_items/new.html.erb
+++ b/app/views/bartered_items/new.html.erb
@@ -1,2 +1,69 @@
-<h1>BarteredItems#new</h1>
-<p>Find me in app/views/bartered_items/new.html.erb</p>
+<div class='container'>
+  
+  <div class="row" style="margin:30px 50px 40px 20px">
+    <div class="col-lg-3 offset-lg-2">
+      <h3 style="background-color: #FFE28C;vertical-align: middle;text-align: center;">譲渡アイテム</h3>
+    </div>
+  </div>
+  
+  <%= form_with model:@bartered_item, local:true do |f| %>
+  <div class='row'>
+    <div class="col-lg-2">画像アップロード</div>
+    <div class="col-lg-2">
+      <div class="form-group">
+        <%= f.attachment_field :bartered_item_images_images, multiple: true %>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-lg-2">タイトル</div>
+    <div class="col-lg-4">
+      <div class="form-group">
+        <%= f.text_field :title, class:"form-control"%>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-lg-2">譲渡アイテム詳細</div>
+    <div class="col-lg-4">
+      <div class="form-group">
+        <%= f.text_field :explanation, class:"form-control"%>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-lg-2">交換方法</div>
+    <div class="col-lg-4">
+      <div class="form-group">
+        <%= f.radio_button :barter_way, :郵送のみ %>
+        <%= f.label :barter_way, '郵送のみ' %>
+        <%= f.radio_button :barter_way, :手渡しのみ %>
+        <%= f.label :barter_way, '手渡しのみ' %>
+        <%= f.radio_button :barter_way, :郵送・手渡し両方可%>
+        <%= f.label :barter_way, '郵送・手渡し両方可' %>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-lg-2">交換希望場所</div>
+    <div class="col-lg-4">
+      <div>
+        <%= f.select :desired_place, BarteredItem.desired_places.keys, {} %>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-lg-2">タグ</div>
+    <div class="col-lg-4">
+      <div class="form-group">
+      </div>
+    </div>
+  </div>
+  <div class="row" style="margin:30px 10px 0px 10px">
+    <div class="col-lg-2 offset-lg-2">    
+      <%= f.hidden_field :user_id, :value => current_user.id %>
+      <%= f.submit "作成",class:"btn btn-warning" %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/bartered_items/new.html.erb
+++ b/app/views/bartered_items/new.html.erb
@@ -2,7 +2,7 @@
   
   <div class="row" style="margin:30px 50px 40px 20px">
     <div class="col-lg-3 offset-lg-2">
-      <h3 style="background-color: #FFE28C;vertical-align: middle;text-align: center;">譲渡アイテム</h3>
+      <h3 style="background-color: #FFE28C;vertical-align: middle;text-align: center;">譲渡アイテム 新規追加</h3>
     </div>
   </div>
   
@@ -52,13 +52,6 @@
       </div>
     </div>
   </div>
-  <div class="row">
-    <div class="col-lg-2">タグ</div>
-    <div class="col-lg-4">
-      <div class="form-group">
-      </div>
-    </div>
-  </div>
   <div class="row" style="margin:30px 10px 0px 10px">
     <div class="col-lg-2 offset-lg-2">    
       <%= f.hidden_field :user_id, :value => current_user.id %>
@@ -67,3 +60,4 @@
     </div>
   </div>
 </div>
+

--- a/app/views/bartered_items/show.html.erb
+++ b/app/views/bartered_items/show.html.erb
@@ -1,0 +1,2 @@
+<h1>BarteredItems#show</h1>
+<p>Find me in app/views/bartered_items/show.html.erb</p>

--- a/app/views/bartered_items/show.html.erb
+++ b/app/views/bartered_items/show.html.erb
@@ -1,4 +1,4 @@
-<h1>BarteredItems#show</h1>
+<h3>譲渡アイテム　詳細</h3>
 <%= @bartered_item.user.nick_name %>
 <br>
 <%= @bartered_item.title %>

--- a/app/views/bartered_items/show.html.erb
+++ b/app/views/bartered_items/show.html.erb
@@ -19,3 +19,7 @@
 <% else %>
   画像はありません。
 <% end %>
+<br>
+<div class="col-lg-2">
+    <%= link_to "編集する", edit_bartered_item_path, class: "btn btn-warning" %>
+</div>

--- a/app/views/bartered_items/show.html.erb
+++ b/app/views/bartered_items/show.html.erb
@@ -1,2 +1,21 @@
 <h1>BarteredItems#show</h1>
-<p>Find me in app/views/bartered_items/show.html.erb</p>
+<%= @bartered_item.user.nick_name %>
+<br>
+<%= @bartered_item.title %>
+<br>
+<%= @bartered_item.explanation %>
+<br>
+<%= @bartered_item.barter_way %>
+<br>
+<%= @bartered_item.desired_place %>
+<br>
+<%= @bartered_item.barter_status %>
+<br>
+<% if @bartered_item.bartered_item_images.present? %>
+  <% @bartered_item.bartered_item_images.each do |image| %>
+    <%= attachment_image_tag image, :image, class: "default_image" %>
+    <br>
+  <% end %>
+<% else %>
+  画像はありません。
+<% end %>

--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -1,2 +1,2 @@
 <h1>Homes</h1>
-
+<%= link_to "譲渡アイテムを追加する", new_bartered_item_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,9 +10,21 @@
   </head>
 
   <body>
+      <li>
+        <%= link_to "一覧へ", bartered_items_path %>
+      </li>
+      <div>
+        <%= form_with url: search_path, method: :get, local: true do |f| %>
+          <%= f.text_field :keyword, value: @keyword %>
+          <%= f.submit "検索" %>
+        <% end %>
+      </div>
      <% if user_signed_in? %>
       <li>
         <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
+      </li>
+      <li>
+        <%= link_to "トップへ", root_path %>
       </li>
     <% else %>
       <li>
@@ -21,7 +33,11 @@
       <li>
         <%= link_to "ログイン", new_user_session_path %>
       </li>
+      <li>
+        <%= link_to "トップへ", root_path %>
+      </li>
     <% end %>
+     <p id="notice"><%= notice %></p>
     <%= yield %>
   </body>
 </html>

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -6,3 +6,5 @@
 #     https: false
 #   )
 # end
+
+Refile.secret_key = 'a6e9b34969f91f67ca33113c963ac2c5a7fb18cfaef4e0fab8ae691f2e5f115f84ef24b8521018ea0dc2dfcf28927dec891e58b43a214f1394b13fbf6b5e9913'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   get 'about' => 'homes#about' 
   resources :bartered_items, except: [:destroy]
   patch 'bartered_items/:id/delete' => 'bartered_items#delete', as: 'barter_delete'
+  get 'search' => 'bartered_items#search'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'homes#top'
   get 'about' => 'homes#about' 
+  resources :bartered_items, except: [:destroy]
+  patch 'bartered_items/:id/delete' => 'bartered_items#delete', as: 'barter_delete'
 end

--- a/db/migrate/20211007031328_create_bartered_items.rb
+++ b/db/migrate/20211007031328_create_bartered_items.rb
@@ -1,0 +1,19 @@
+class CreateBarteredItems < ActiveRecord::Migration[5.2]
+  def change
+    create_table :bartered_items do |t|
+      
+      t.integer :user_id, null: false
+      t.string :title, null: false
+      t.text :explanation, null: false
+      t.integer :barter_way, null: false
+      t.integer :desired_place, null: false
+      t.integer :no1_wanted_item_id
+      t.integer :no2_wanted_item_id
+      t.integer :no3_wanted_item_id
+      t.integer :barter_status, null: false, default: 0
+      t.boolean :is_deleted, null: false, default: false
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211007051906_create_bartered_item_images.rb
+++ b/db/migrate/20211007051906_create_bartered_item_images.rb
@@ -1,0 +1,11 @@
+class CreateBarteredItemImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :bartered_item_images do |t|
+      
+      t.integer :bartered_item_id, null: false
+      t.string :image_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_07_031328) do
+ActiveRecord::Schema.define(version: 2021_10_07_051906) do
+
+  create_table "bartered_item_images", force: :cascade do |t|
+    t.integer "bartered_item_id", null: false
+    t.string "image_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "bartered_items", force: :cascade do |t|
     t.integer "user_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_07_015744) do
+ActiveRecord::Schema.define(version: 2021_10_07_031328) do
+
+  create_table "bartered_items", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "title", null: false
+    t.text "explanation", null: false
+    t.integer "barter_way", null: false
+    t.integer "desired_place", null: false
+    t.integer "no1_wanted_item_id"
+    t.integer "no2_wanted_item_id"
+    t.integer "no3_wanted_item_id"
+    t.integer "barter_status", default: 0, null: false
+    t.boolean "is_deleted", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/test/controllers/bartered_items_controller_test.rb
+++ b/test/controllers/bartered_items_controller_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class BarteredItemsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get bartered_items_new_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get bartered_items_edit_url
+    assert_response :success
+  end
+
+  test "should get index" do
+    get bartered_items_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get bartered_items_show_url
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/bartered_item_images.yml
+++ b/test/fixtures/bartered_item_images.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/bartered_items.yml
+++ b/test/fixtures/bartered_items.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/bartered_item_image_test.rb
+++ b/test/models/bartered_item_image_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class BarteredItemImageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/bartered_item_test.rb
+++ b/test/models/bartered_item_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class BarteredItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
・複数の検索ワードの全てが、titleカラム、explanationカラムのどちらかに入っているbartered_itemのレコードを取得します。
・検索欄が未入力または空白のみの場合は譲渡アイテム一覧を表示し、検索欄へ入力する指示文言も表示されます。